### PR TITLE
post 時にデータをquery string に含めずに post param にする

### DIFF
--- a/lib/robot_payment/charge.rb
+++ b/lib/robot_payment/charge.rb
@@ -24,34 +24,25 @@ module RobotPayment
     end
 
     def create_by_gateway  # Deprecated due to security, so this is ONLY TEST method for gateway.
-      client = Faraday.new(url: gateway_charge_uri)
+      client = Faraday.new
       charge = RobotPayment::Charge.new
-      url = charge.gateway_query_builder
-      client.post url
+      url = gateway_charge_uri
+      client.post url, test_params
     end
 
     def create_by_token(params)
-      client = Faraday.new(url: gateway_charge_uri)  # TODO client = RobotPayment::Client.new
+      client = Faraday.new
       charge = RobotPayment::Charge.new
-      url = charge.token_query_builder(params)
-      client.post url
+      url = token_charge_uri
+      client.post url, post_params(params)
     end
 
-    def gateway_query_builder
-      "#{gateway_charge_uri}?#{test_params}"
-    end
-
-    def token_query_builder(params)
-      "#{token_charge_uri}?#{basic_params(params)}"
-    end
-
-    def basic_params(params)
+    def post_params(params)
       q = {
         aid: RobotPayment.config.aid,
         rt:  RobotPayment.config.rt,
         jb:  RobotPayment.config.jb }
       q.merge!(params) if params
-      q = q.map{|key,val| "#{key}=#{val}"}.join("&")
     end
 
     def test_params
@@ -67,7 +58,6 @@ module RobotPayment
         em:  "mika.mizuno@knowledgelabo.com",
         pn:  "0668097072",
         iid: "cs001"}
-      q = q.map{|key,val| "#{key}=#{val}"}.join("&")
     end
 
     def valid?


### PR DESCRIPTION
https://github.com/knowledgelabo/Manageee/issues/936
https://github.com/knowledgelabo/kl_payment_api/issues/14
```
faraday = Faraday.new
url = "http://localhost:3000"
faraday.post url, {data1: "email+1@gmail.com"}

# post先URL "http://localhost:3000/"
# データ data1=email%2B%40gmail.com
```

データをurl中に含めると勿論エンコードされないが、
パラメータとするとURLエンコードされるので、そのようにした

わりかし凡ミスの類で、初めに実装した方法がよくなかったです…